### PR TITLE
Use RTD theme locally, but keep as-is otherwise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ hieroglyph==0.6.5
 six==1.6.1
 sphinxcontrib-fulltoc==1.0
 wsgiref==0.1.2
+sphinx-rtd-theme==0.1.6

--- a/source/conf.py
+++ b/source/conf.py
@@ -252,3 +252,8 @@ texinfo_documents = [
 #texinfo_show_urls = 'footnote'
 
 slide_theme_options = {'custom_css': 'custom.css'}
+
+if not os.environ.get('READTHEDOCS', None):
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
Lets start using the Read The Docs theme locally while we work on the site but
make sure we don't interfere with how it works on RTD itself.
