### PR TITLE
Change main page title to DevOps Bootcamp

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -1,4 +1,4 @@
-DevOps Daycamp
+DevOps Bootcamp
 ==============
 
 Recurring meetings will be Mondays, 7pm-9pm in KEC1005.  Changes will be announced here!


### PR DESCRIPTION
The header and title of the main page are wrong.

@lucywyman @jordane r?
