### PR TITLE
Add inital quick-git-setup slide

### DIFF
--- a/source/01_the_very_basics.rst
+++ b/source/01_the_very_basics.rst
@@ -89,6 +89,26 @@ Installing Linux on Virtualbox
     #. Start -> press enter -> Skip media check
 #. ``\o/``
 
+Installing Git
+--------------
+**Linux:**
+
+.. code-block:: bash
+
+    $ sudo apt-get install git # Ubuntu / Debian / Mint
+    $ sudo yum install git # RHEL / Fedora / Centos
+
+**Mac / Windows:** Go to http://git-scm.com and download the version of `git`
+for your operating system. You can also investigate installing a *package
+manager* to make installation of programs like git easier in the future.
+
+- Windows: https://chocolatey.org/
+- Mac: http://brew.sh/
+
+**Windows** users should use the `git-shell` for the following commands on
+the next slides to spin up and use their vagrant virtualmachines.
+
+
 Vagrant & VirtualBox
 --------------------
 


### PR DESCRIPTION
refs #25
I have added a slide that instructs users on how to install git before we tell them to clone a repo for the first time since we have no prior documentation on this. I tell them to get git from git-scm.com because it includes a shell for windows users however we can tell them to use the GitHub tools instead which include similar tools. My thoughts are that I want to stress Git is not the same as GitHub however the GH tool might be better and easier to setup. Thoughts? @ramereth @edunham @iankronquist @lucywyman [others]