### PR TITLE
Remove Yaourt from package managers

### DIFF
--- a/source/packages-software-libraries.rst
+++ b/source/packages-software-libraries.rst
@@ -259,10 +259,10 @@ Other Package Managers
     Below are a few more notable/interesting package managers.
 
 Portage
-    The Source-based package manager for  Gentoo.
+    The Source-based package manager for Gentoo.
 
-Yaourt
-    An Arch User Repository wrapper for Pacman, the Arch Linux Package manager.
+Pacman
+    The Simple Arch Linux Package manager.
 
 Nix
     A 'Fully Functional/Transactional' package manager.


### PR DESCRIPTION
Yaourt itself isn't a package manager, it is a wrapper around a package manager for Arch Linux. Besides that it's [horribly unsafe and out of date](https://wiki.archlinux.org/index.php/AUR_helpers).